### PR TITLE
Styling improvements

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,10 +16,10 @@
 		<link rel="icon" type="image/ico" href="{{'/favicon.ico' | absolute_url}}">
 
 		<!-- CSS -->
-		<link rel="stylesheet" href="{{'/assets/css/main.css' | absolute_url}}">
+		<link rel="stylesheet" href="{{'/assets/css/main.css' | relative_url}}">
 
 		<!-- KATEX -->
-		<link rel="stylesheet" href="{{'/assets/css/katex.min.css' | absolute_url}}">
+		<link rel="stylesheet" href="{{'/assets/css/katex.min.css' | relative_url}}">
 
 		<!-- CANONICAL -->
 		<link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">

--- a/_sass/_highlight.sass
+++ b/_sass/_highlight.sass
@@ -1,0 +1,227 @@
+.highlight
+    .hll
+        background-color: #ffffcc
+    // Comment
+    .c
+        color: #408080
+        font-style: italic
+    // Error
+    .err
+        border: 1px solid #FF0000
+    // Keyword
+    .k
+        color: #008000
+        font-weight: bold
+    // Operator
+    .o
+        color: #666666
+    // Comment.Hashbang
+    .ch
+        color: #408080
+        font-style: italic
+    // Comment.Multiline
+    .cm
+        color: #408080
+        font-style: italic
+    // Comment.Preproc
+    .cp
+        color: #BC7A00
+    // Comment.PreprocFile
+    .cpf
+        color: #408080
+        font-style: italic
+    // Comment.Single
+    .c1
+        color: #408080
+        font-style: italic
+    // Comment.Special
+    .cs
+        color: #408080
+        font-style: italic
+    // Generic.Deleted
+    .gd
+        color: #A00000
+    // Generic.Emph
+    .ge
+        font-style: italic
+    // Generic.Error
+    .gr
+        color: #FF0000
+    // Generic.Heading
+    .gh
+        color: #000080
+        font-weight: bold
+    // Generic.Inserted
+    .gi
+        color: #00A000
+    // Generic.Output
+    .go
+        color: #606060
+    // Generic.Prompt
+    .gp
+        color: #000080
+        font-weight: bold
+    // Generic.Strong
+    .gs
+        font-weight: bold
+    // Generic.Subheading
+    .gu
+        color: #800080
+        font-weight: bold
+    // Generic.Traceback
+    .gt
+        color: #0044DD
+    // Keyword.Constant
+    .kc
+        color: #008000
+        font-weight: bold
+    // Keyword.Declaration
+    .kd
+        color: #008000
+        font-weight: bold
+    // Keyword.Namespace
+    .kn
+        color: #008000
+        font-weight: bold
+    // Keyword.Pseudo
+    .kp
+        color: #008000
+    // Keyword.Reserved
+    .kr
+        color: #008000
+        font-weight: bold
+    // Keyword.Type
+    .kt
+        color: #B00040
+    // Literal.Number
+    .m
+        color: #666666
+    // Literal.String
+    .s
+        color: #BA2121
+    // Name.Attribute
+    .na
+        color: #7D9029
+    // Name.Builtin
+    .nb
+        color: #008000
+    // Name.Class
+    .nc
+        color: #0000FF
+        font-weight: bold
+    // Name.Constant
+    .no
+        color: #880000
+    // Name.Decorator
+    .nd
+        color: #AA22FF
+    // Name.Entity
+    .ni
+        color: #999999
+        font-weight: bold
+    // Name.Exception
+    .ne
+        color: #D2413A
+        font-weight: bold
+    // Name.Function
+    .nf
+        color: #0000FF
+    // Name.Label
+    .nl
+        color: #A0A000
+    // Name.Namespace
+    .nn
+        color: #0000FF
+        font-weight: bold
+    // Name.Tag
+    .nt
+        color: #008000
+        font-weight: bold
+    // Name.Variable
+    .nv
+        color: #19177C
+    // Operator.Word
+    .ow
+        color: #AA22FF
+        font-weight: bold
+    // Text.Whitespace
+    .w
+        color: #bbbbbb
+    // Literal.Number.Bin - Metal af
+    .mb
+        color: #666666
+    // Literal.Number.Float
+    .mf
+        color: #666666
+    // Literal.Number.Hex
+    .mh
+        color: #666666
+    // Literal.Number.Integer
+    .mi
+        color: #666666
+    // Literal.Number.Oct
+    .mo
+        color: #666666
+    // Literal.String.Affix
+    .sa
+        color: #BA2121
+    // Literal.String.Backtick
+    .sb
+        color: #BA2121
+    // Literal.String.Char
+    .sc
+        color: #BA2121
+    // Literal.String.Delimiter 
+    .dl
+        color: #BA2121
+    // Literal.String.Doc
+    .sd
+        color: #BA2121
+        font-style: italic
+    // Literal.String.Double
+    .s2
+        color: #BA2121
+    // Literal.String.Escape
+    .se
+        color: #BB6622
+        font-weight: bold
+    // Literal.String.Heredoc
+    .sh
+        color: #BA2121
+    // Literal.String.Interpol
+    .si
+        color: #BB6688
+        font-weight: bold
+    // Literal.String.Other
+    .sx
+        color: #008000
+    // Literal.String.Regex
+    .sr
+        color: #BB6688
+    // Literal.String.Single
+    .s1
+        color: #BA2121
+    // Literal.String.Symbol
+    .ss
+        color: #19177C
+    // Name.Builtin.Pseudo
+    .bp
+        color: #008000
+    // Name.Function.Magic
+    .fm
+        color: #0000FF
+    // Name.Variable.Class
+    .vc
+        color: #19177C
+    // Name.Variable.Global
+    .vg
+        color: #19177C
+    // Name.Variable.Instance
+    .vi
+        color: #19177C
+    // Name.Variable.Magic
+    .vm
+        color: #19177C
+    // Literal.Number.Integer.Long
+    .il
+        color: #666666

--- a/_sass/_main.sass
+++ b/_sass/_main.sass
@@ -28,6 +28,15 @@ $text-color: #000 // text colors
 $quote-color: #606060
 $link-color: #03d
 
+/* Dark mode colors */
+$text-color-dark: #fff
+$link-color-dark: rgb(71, 154, 255)
+$blockquote-color-dark: rgb(171, 164, 153)
+$border-color-dark: rgb(106, 99, 87)
+$background-dark: #181a1b
+$background-light-dark: rgb(24, 26, 27)
+$background-lighter-dark: rgb(43, 46, 48)
+
 $code-background-color: #f2f2f2 // background colors
 
 /* FONT SETTINGS */
@@ -314,20 +323,20 @@ body
 
 @media (prefers-color-scheme: dark)
   body
-    background: #181a1b
+    background: $background-dark
   body, .current-page-item a, .header a h1, h1
-    color: white !important
+    color: $text-color-dark !important
   a
-    color: rgb(71, 154, 255) !important
+    color: $link-color-dark !important
   td
-    border-color: rgb(106, 99, 87)
-    background-color: rgb(24, 26, 27)
+    border-color: $border-color-dark
+    background-color: $background-light-dark
   table
-    color: rgb(200, 195, 188)
+    color: $text-color-dark
   th
-    border-color: rgb(106, 99, 87)
-    background-color: rgb(43, 46, 48)
+    border-color: $border-color-dark
+    background-color: $background-lighter-dark
   blockquote
-    color: rgb(171, 164, 153)
+    color: $blockquote-color-dark
   img.invertable
     filter: invert(.8)

--- a/_sass/_main.sass
+++ b/_sass/_main.sass
@@ -1,14 +1,15 @@
 @charset "utf-8"
+@import "highlight"
 
 /* SIZE DEFINITIONS */
-$website-size: 800px            // width of content of the website
-$website-padding: 25px          // left/right padding of website content
-$header-padding: 10px           // top/bottom padding of header
-$navigation-padding: 20px       // top/bottom padding of navbar
-$navigation-item-spacing: 20px  // spacing between each of the navigation items
-$code-padding: 6px              // padding for inline code, half padding for block code
-$code-border-roundness: 10px    // roundness of the code border
-$table-cell-spacing: 10px       // default cell spacing for tables
+$website-size: 800px // width of content of the website
+$website-padding: 25px // left/right padding of website content
+$header-padding: 10px // top/bottom padding of header
+$navigation-padding: 20px // top/bottom padding of navbar
+$navigation-item-spacing: 20px // spacing between each of the navigation items
+$code-padding: 6px // padding for inline code, half padding for block code
+$code-border-roundness: 10px // roundness of the code border
+$table-cell-spacing: 10px // default cell spacing for tables
 
 /* relative sizes of certain website elements */
 $title-size: 350%
@@ -16,14 +17,14 @@ $post-date-size: 115%
 $small-size: 90%
 
 /* text formatting */
-$line-spacing: 20px    // spacing after paragraph
-$h1-spacing: 12px      // spacing after h1
-$h2-spacing: 10px      // spacing after h2
-$h3-spacing: 8px       // spacing after h3
-$item-padding: 25px    // list and blockquote padding
+$line-spacing: 20px // spacing after paragraph
+$h1-spacing: 12px // spacing after h1
+$h2-spacing: 10px // spacing after h2
+$h3-spacing: 8px // spacing after h3
+$item-padding: 25px // list and blockquote padding
 
 /* COLOR DEFINITIONS */
-$text-color: #000      // text colors
+$text-color: #000 // text colors
 $quote-color: #606060
 $link-color: #03d
 
@@ -84,7 +85,7 @@ $monospaced-font: "Roboto Mono"
   td
     padding-right: $table-cell-spacing
 
-  margin-bottom: $line-spacing
+    margin-bottom: $line-spacing
 
 // wiki-like table class
 .wiki-table
@@ -148,9 +149,9 @@ $monospaced-font: "Roboto Mono"
     overflow-x: auto
     padding: $code-padding
 
-  border-radius: $code-border-roundness
-  padding: ($code-padding / 2) $code-padding
-  margin-bottom: $line-spacing
+    border-radius: $code-border-roundness
+    padding: ($code-padding / 2) $code-padding
+    margin-bottom: $line-spacing
 
 // useful CSS classes
 .small
@@ -273,250 +274,21 @@ body
   color: $text-color
 
   a
-    color: $link-color !important
+    color: $link-color
 
     &:hover
-      color: $text-color !important
+      color: $text-color
 
   blockquote
     color: $quote-color
 
   .current-page-item, .header
     a, h1
-      color: $text-color !important
+      color: $text-color
 
   .highlight, .highlighter-rouge
     background-color: $code-background-color
     border-color: $code-background-color
-
-  .highlight
-    .hll
-      background-color: #ffffcc
-    // Comment
-    .c
-      color: #408080
-      font-style: italic
-    // Error
-    .err
-      border: 1px solid #FF0000
-    // Keyword
-    .k
-      color: #008000
-      font-weight: bold
-    // Operator
-    .o
-      color: #666666
-    // Comment.Hashbang
-    .ch
-      color: #408080
-      font-style: italic
-    // Comment.Multiline
-    .cm
-      color: #408080
-      font-style: italic
-    // Comment.Preproc
-    .cp
-      color: #BC7A00
-    // Comment.PreprocFile
-    .cpf
-      color: #408080
-      font-style: italic
-    // Comment.Single
-    .c1
-      color: #408080
-      font-style: italic
-    // Comment.Special
-    .cs
-      color: #408080
-      font-style: italic
-    // Generic.Deleted
-    .gd
-      color: #A00000
-    // Generic.Emph
-    .ge
-      font-style: italic
-    // Generic.Error
-    .gr
-      color: #FF0000
-    // Generic.Heading
-    .gh
-      color: #000080
-      font-weight: bold
-    // Generic.Inserted
-    .gi
-      color: #00A000
-    // Generic.Output
-    .go
-      color: #606060
-    // Generic.Prompt
-    .gp
-      color: #000080
-      font-weight: bold
-    // Generic.Strong
-    .gs
-      font-weight: bold
-    // Generic.Subheading
-    .gu
-      color: #800080
-      font-weight: bold
-    // Generic.Traceback
-    .gt
-      color: #0044DD
-    // Keyword.Constant
-    .kc
-      color: #008000
-      font-weight: bold
-    // Keyword.Declaration
-    .kd
-      color: #008000
-      font-weight: bold
-    // Keyword.Namespace
-    .kn
-      color: #008000
-      font-weight: bold
-    // Keyword.Pseudo
-    .kp
-      color: #008000
-    // Keyword.Reserved
-    .kr
-      color: #008000
-      font-weight: bold
-    // Keyword.Type
-    .kt
-      color: #B00040
-    // Literal.Number
-    .m
-      color: #666666
-    // Literal.String
-    .s
-      color: #BA2121
-    // Name.Attribute
-    .na
-      color: #7D9029
-    // Name.Builtin
-    .nb
-      color: #008000
-    // Name.Class
-    .nc
-      color: #0000FF
-      font-weight: bold
-    // Name.Constant
-    .no
-      color: #880000
-    // Name.Decorator
-    .nd
-      color: #AA22FF
-    // Name.Entity
-    .ni
-      color: #999999
-      font-weight: bold
-    // Name.Exception
-    .ne
-      color: #D2413A
-      font-weight: bold
-    // Name.Function
-    .nf
-      color: #0000FF
-    // Name.Label
-    .nl
-      color: #A0A000
-    // Name.Namespace
-    .nn
-      color: #0000FF
-      font-weight: bold
-    // Name.Tag
-    .nt
-      color: #008000
-      font-weight: bold
-    // Name.Variable
-    .nv
-      color: #19177C
-    // Operator.Word
-    .ow
-      color: #AA22FF
-      font-weight: bold
-    // Text.Whitespace
-    .w
-      color: #bbbbbb
-    // Literal.Number.Bin - Metal af
-    .mb
-      color: #666666
-    // Literal.Number.Float
-    .mf
-      color: #666666
-    // Literal.Number.Hex
-    .mh
-      color: #666666
-    // Literal.Number.Integer
-    .mi
-      color: #666666
-    // Literal.Number.Oct
-    .mo
-      color: #666666
-    // Literal.String.Affix
-    .sa
-      color: #BA2121
-    // Literal.String.Backtick
-    .sb
-      color: #BA2121
-    // Literal.String.Char
-    .sc
-      color: #BA2121
-    // Literal.String.Delimiter 
-    .dl
-      color: #BA2121
-    // Literal.String.Doc
-    .sd
-      color: #BA2121
-      font-style: italic
-    // Literal.String.Double
-    .s2
-      color: #BA2121
-    // Literal.String.Escape
-    .se
-      color: #BB6622
-      font-weight: bold
-    // Literal.String.Heredoc
-    .sh
-      color: #BA2121
-    // Literal.String.Interpol
-    .si
-      color: #BB6688
-      font-weight: bold
-    // Literal.String.Other
-    .sx
-      color: #008000
-    // Literal.String.Regex
-    .sr
-      color: #BB6688
-    // Literal.String.Single
-    .s1
-      color: #BA2121
-    // Literal.String.Symbol
-    .ss
-      color: #19177C
-    // Name.Builtin.Pseudo
-    .bp
-      color: #008000
-    // Name.Function.Magic
-    .fm
-      color: #0000FF
-    // Name.Variable.Class
-    .vc
-      color: #19177C
-    // Name.Variable.Global
-    .vg
-      color: #19177C
-    // Name.Variable.Instance
-    .vi
-      color: #19177C
-    // Name.Variable.Magic
-    .vm
-      color: #19177C
-    // Literal.Number.Integer.Long
-    .il
-      color: #666666
-
 
 /* Footer styling */
 .related

--- a/_sass/_main.sass
+++ b/_sass/_main.sass
@@ -311,3 +311,23 @@ body
 @media print
   header, footer
     display: none
+
+@media (prefers-color-scheme: dark)
+  body
+    background: #181a1b
+  body, .current-page-item a, .header a h1, h1
+    color: white !important
+  a
+    color: rgb(71, 154, 255) !important
+  td
+    border-color: rgb(106, 99, 87)
+    background-color: rgb(24, 26, 27)
+  table
+    color: rgb(200, 195, 188)
+  th
+    border-color: rgb(106, 99, 87)
+    background-color: rgb(43, 46, 48)
+  blockquote
+    color: rgb(171, 164, 153)
+  img.invertable
+    filter: invert(.8)

--- a/o-vesnici.md
+++ b/o-vesnici.md
@@ -9,11 +9,11 @@ Meziklasí (japonsky 耳の間) je s největší pravděpodobností vesnice, nac
   <tr><th colspan="2">Základní informace o vesnici</th></tr>
   <tr>
     <td>
-      <img src="/assets/img/zaba.png" alt="Maskot" />
+      <img src="/assets/img/zaba.png" alt="Maskot" class="invertable" />
 	  <figcaption>Maskot</figcaption>
     </td>
     <td>
-      <img src="/assets/img/logo.png" alt="Znak" />
+      <img src="/assets/img/logo.png" alt="Znak" class="invertable" />
 	  <figcaption>Znak</figcaption>
     </td>
   </tr>


### PR DESCRIPTION
See commits for exact details on everything changed, but most notably:
- fixed the fact styles wouldn't reflect locally when you change them (https://github.com/Meziklassociation/meziklasi/commit/d896a1d82c33875c15aa5f1e5a120ec5c6cac3ed)
- added dark mode (activated by [`preferes-color-scheme`](https://web.dev/prefers-color-scheme/#the-prefers-color-scheme-media-query))
	- There's now a `invertable` image class, which enables purely black images to be white in dark mode (see `/o-vesnici/` or screenshot below)

![image](https://user-images.githubusercontent.com/29888641/183267678-09d38ca0-3347-4890-9977-c81ed55505da.png)
