### PR TITLE
Move page title in front of site title

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
 		{% if page.order == 0 %}
 			<title>{{ site.title | split: " " | first }}</title>
 		{% else %}
-			<title>{{ site.title | split: " " | first }} – {{ page.title }}</title>
+			<title>{{ page.title }} – {{ site.title | split: " " | first }}</title>
 		{% endif %}
 		<meta name="description" content="{{site.description}}">
 


### PR DESCRIPTION
This PR turns this

![image](https://user-images.githubusercontent.com/29888641/183268196-cc2e730d-88e2-4c06-a64e-2097de17e54d.png)

into this

![image](https://user-images.githubusercontent.com/29888641/183268174-5e622b30-6815-4a2c-a1b3-cfacd385cbae.png)

## Why?

Good question. This is because the page `<title>` should include critical parts of the page's content, to be easily distinguishable - if you have multiple Meziklasí tabs open at the same time, you could only see just `Meziklasí -`, which wouldn't be very helpful, like this: (these could all be different pages).
![image](https://user-images.githubusercontent.com/29888641/183268251-4f1172a0-fc61-474c-a4a8-424868f11884.png)

I thought this was pretty set and stone, but looks like the current state of things could also benefit us, I found a pretty interesting [Stackexchange thread](https://webmasters.stackexchange.com/questions/16251/should-site-title-be-before-or-after-page-title). I also found the SEO note on [the MDN `<title>` doc](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title#page_titles_and_seo) a nice resource.