### PR TITLE
Add `sitemap.xml` generation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "jekyll"
+gem 'jekyll-sitemap'
 gem "execjs"
 gem "kramdown-math-katex"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,8 @@ GEM
       terminal-table (~> 2.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     katex (0.8.0)
@@ -70,6 +72,7 @@ PLATFORMS
 DEPENDENCIES
   execjs
   jekyll
+  jekyll-sitemap
   kramdown-math-katex
   webrick (~> 1.7)
 

--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,9 @@ permalink: /:categories/:title/
 
 markdown: kramdown
 
+plugins:
+  - jekyll-sitemap
+
 kramdown:
   math_engine: katex
 


### PR DESCRIPTION
Sitemaps are nice, as [an article](https://www.merkle.com/in/blog/sitemaps-and-their-importance-seo) on merkle.com states:
> A sitemap lists a website's most important pages, thus, making sure search engines can find and crawl them. Sitemaps also help in understanding your website structure, making it easier to navigate your website.

This PR adds automatic generation of a sitemap, with only one con that I found: the last modified dates are wrong, since they default to the published dates [[1](https://github.com/jekyll/jekyll-sitemap#lastmod-tag)] - we should think about implementing last modified fields on our pages and posts. 

## How to test

Pull changes and visit `/sitemap.xml`.