### PR TITLE
Add adaptive images

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,67 @@
+name: Publish to GitHub Pages
+
+# Run when new code is pushed to one of the main branches. Also provide a button for manual deploys.
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+# Cancel any runs in progress -- just complete the latest run
+concurrency:
+  group: github_pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    # Grab a Linux runner from the pool
+    runs-on: ubuntu-latest
+    # Publishing needs to write to the gh-pages branch
+    permissions:
+      contents: write
+    steps:
+      # Jekyll Picture Tag requires libvips libraries for resizing images, which must be installed
+      - name: Install JPT's dependencies
+        run: sudo apt-get install libvips-tools
+
+      # Put repository source onto the runner so we can build it
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Install the proper version of Ruby and run bundle install
+      - name: 💎 Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      # Build the site
+      - name: 🧪 Jekyll build
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+      - name: ⏫ Upload artifact to GitHub Pages
+        id: artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: _site/
+
+  deploy:
+    # Add a dependency to the build job
+    needs: build
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,10 +29,15 @@ jobs:
         uses: actions/checkout@v3
 
       # Install the proper version of Ruby and run bundle install
-      - name: 💎 Setup ruby
+      - name: 💎 Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+
+      - name: ✨ Setup Node
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
       # Build the site
       - name: 🧪 Jekyll build

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,4 @@
+# You can find the new timestamped tags here: https://hub.docker.com/r/gitpod/workspace-base/tags
+FROM gitpod/workspace-ruby-2
+
+RUN sudo install-packages shellcheck tree libvips libvips-dev libvips-tools

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
 # You can find the new timestamped tags here: https://hub.docker.com/r/gitpod/workspace-base/tags
 FROM gitpod/workspace-ruby-2
 
-RUN sudo install-packages shellcheck tree libvips libvips-dev libvips-tools
+RUN sudo install-packages shellcheck tree libvips libvips-dev libvips-tools nodejs

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,6 @@
+image:
+  file: .gitpod.Dockerfile
+
 tasks:
   - init: bundle install
     command: bundle exec jekyll serve

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,9 @@ gem 'jekyll-sitemap'
 gem "execjs"
 gem "kramdown-math-katex"
 
+group :jekyll_plugins do
+    # (other jekyll plugins)
+    gem 'jekyll_picture_tag', '~> 2.0'
+  end
+
 gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,13 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    jekyll_picture_tag (2.0.3)
+      addressable (~> 2.6)
+      jekyll (~> 4.0)
+      mime-types (~> 3.0)
+      objective_elements (~> 1.1)
+      rainbow (~> 3.0)
+      ruby-vips (~> 2.0.17)
     katex (0.8.0)
       execjs (~> 2.7)
     kramdown (2.3.1)
@@ -50,14 +57,21 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
+    objective_elements (1.1.2)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
+    rainbow (3.1.1)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
     rouge (3.26.0)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -73,6 +87,7 @@ DEPENDENCIES
   execjs
   jekyll
   jekyll-sitemap
+  jekyll_picture_tag (~> 2.0)
   kramdown-math-katex
   webrick (~> 1.7)
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This repository contains the source code to [meziklasi.cz](http://meziklasi.cz/)
 - Ruby (tested on 2.7)
 - Bundler (`gem install bundler`)
 - Jekyll (`gem install jekyll`)
+- Node.js
+
+For image generation, `libvips` is required. This can be installed with `apt` by executing `sudo apt install libvips libvips-dev libvips-tools` or on other platforms as described in [`libvips`'s docs](https://www.libvips.org/install.html).
 
 ### Development
 To start the development server, you can simple execute the following command and then go to [localhost:4000](http://localhost:4000/).

--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,13 @@ kramdown:
 
 show_related: true
 
+picture:
+  source: "assets/img"
+  output: "assets/img/generated"
+  suppress_warnings: true
+  ignore_missing_images: true
+  nomarkdown: false
+
 exclude: ["*.gemspec", "*.gem", "Gemfile", "Gemfile.lock", "scripts/", "ignored/", "LICENSE.txt", "README.md", "Rakefile"]
 
 defaults:

--- a/_data/picture.yml
+++ b/_data/picture.yml
@@ -1,0 +1,4 @@
+presets:
+  default:
+    formats: [webp, png, original]
+    widths: [200, 400, 800, 1200, 1600] # Image widths, in pixels.

--- a/_posts/2019-11-26-nazvoslovi-zvirat.md
+++ b/_posts/2019-11-26-nazvoslovi-zvirat.md
@@ -110,14 +110,14 @@ Zde naleznete několik vět, které se podařilo autorům názvosloví zachytit 
 <table>
   <tbody>
     <tr>
-      <td><figure><img src="/assets/img/nazvoslovi/craboman.webp" alt="Craboman"/><figcaption>Craboman</figcaption></figure></td>
-      <td><figure><img src="/assets/img/nazvoslovi/hipporigami.webp" alt="Hipporigami"/><figcaption>Hipporigami</figcaption></figure></td>
-      <td><figure><img src="/assets/img/nazvoslovi/owlot.webp" alt="Owlot"/><figcaption>Owlot</figcaption></figure></td>
+      <td><figure>{% picture nazvoslovi/craboman.webp --alt Craboman %}<figcaption>Craboman</figcaption></figure></td>
+      <td><figure>{% picture nazvoslovi/hipporigami.webp --alt Hipporigami %}<figcaption>Hipporigami</figcaption></figure></td>
+      <td><figure>{% picture nazvoslovi/owlot.webp --alt Owlot %}<figcaption>Owlot</figcaption></figure></td>
     </tr>
     <tr>
-      <td><figure><img src="/assets/img/nazvoslovi/whalocoin.webp" alt="Whalocoin"/><figcaption>Whalocoin</figcaption></figure></td>
-      <td><figure><img src="/assets/img/nazvoslovi/trilobit.webp" alt="Trilobit"/><figcaption>Trilobit</figcaption></figure></td>
-      <td><figure><img src="/assets/img/nazvoslovi/squirronaut.webp" alt="Squirronaut"/><figcaption>Squirronaut</figcaption></figure></td>
+      <td><figure>{% picture nazvoslovi/whalocoin.webp --alt Whalocoin %}<figcaption>Whalocoin</figcaption></figure></td>
+      <td><figure>{% picture nazvoslovi/trilobit.webp --alt Trilobit %}<figcaption>Trilobit</figcaption></figure></td>
+      <td><figure>{% picture nazvoslovi/squirronaut.webp --alt squirronaut %}<figcaption>Squirronaut</figcaption></figure></td>
     </tr>
   </tbody>
 </table>

--- a/_posts/2019-12-19-PF-2020.md
+++ b/_posts/2019-12-19-PF-2020.md
@@ -3,7 +3,7 @@ title: "PF 2020 🎉"
 category: Novinky
 ---
 
-![PF 2020 Meziklasí](/assets/img/PF-2020.png)
+{% picture PF-2020.png --alt PF 2020 Meziklasí %}
 
 {: .small .centered }
 Děkujeme za podporu našich čtenářů a našich blízkých ♥️.

--- a/_posts/2020-01-01-nalez-historicke-mapy.md
+++ b/_posts/2020-01-01-nalez-historicke-mapy.md
@@ -6,7 +6,7 @@ category: Novinky
 
 V nedávné době jsme mohli být svědky nálezu jednoho z nejvýznamnějších artefaktů meziklasské historie. Jedná se zatím nejpodrobnější historickou mapu Meziklasí a jeho okolí. Mapa byla nalezena v domě jednoho meziklasského usedlíka. Byla totiž nacpaná v díře ve střeše. Pravděpodobně nějaký jeho předek díru mapou zacpal, aby mu neteklo do stavení.
 
-![Scan nalezené historické mapy][mapa]
+{% picture historicka-mapa.png --alt Scan nalezené historické mapy %}
 
 Radiouhlíková metoda určila datum vzniku na rok 2003, což historiky překvapilo. Nikdo z nich totiž nevěřil, že už v té době Meziklasí disponovalo technologiemi na výrobu této mapy. Také je to první záznam toho, že Meziklasané se v minulosti zajímali i o okolí mimo vesnici.
 
@@ -14,5 +14,4 @@ Originál nalezené mapy bude vystaven v meziklasském muzeu hned jakmile bude d
 
 V dnešní době ovšem existují již mnohem podrobnější mapy. Například mapy poskytované společností Google, obsahují satelitní snímky i přesnou polohu [Meziklasského moře][meziklasske-more].
 
-[mapa]: /assets/img/historicka-mapa.png
 [meziklasske-more]: https://goo.gl/maps/cnCgeULtFMbrcEYa7

--- a/_posts/2021-09-27-instantni-voda.md
+++ b/_posts/2021-09-27-instantni-voda.md
@@ -10,6 +10,8 @@ Meziklasští vědci na tento problém objevili revoluční nové řešení: ins
 
 ![Obrázek instantní vody](/assets/img/instavoda.png)
 
+{% picture jpt-webp instavoda.png %}
+
 Stačí přidat vodu a okamžitě máte vodu!
 
 Složení: tajný recept

--- a/_posts/2021-09-27-instantni-voda.md
+++ b/_posts/2021-09-27-instantni-voda.md
@@ -8,9 +8,7 @@ Máte plné zuby tahání těžkých a nepraktických lahví vody na cestách? L
 
 Meziklasští vědci na tento problém objevili revoluční nové řešení: instantní voda!
 
-![Obrázek instantní vody](/assets/img/instavoda.png)
-
-{% picture jpt-webp instavoda.png %}
+{% picture instavoda.png --alt Obrázek instantní vody %}
 
 Stačí přidat vodu a okamžitě máte vodu!
 

--- a/_sass/_main.sass
+++ b/_sass/_main.sass
@@ -339,7 +339,7 @@ body
     background-color: $background-lighter-dark
   blockquote
     color: $blockquote-color-dark
-  img.invertable
+  .invertable
     filter: invert(.8)
   body hr
     background-image: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0))

--- a/o-vesnici.md
+++ b/o-vesnici.md
@@ -9,12 +9,16 @@ Meziklasí (japonsky 耳の間) je s největší pravděpodobností vesnice, nac
   <tr><th colspan="2">Základní informace o vesnici</th></tr>
   <tr>
     <td>
-      <img src="/assets/img/zaba.png" alt="Maskot" class="invertable" />
-	  <figcaption>Maskot</figcaption>
+      <span class="invertable">
+        {% picture zaba.png --alt Maskot %}
+      </span>
+	    <figcaption>Maskot</figcaption>
     </td>
     <td>
-      <img src="/assets/img/logo.png" alt="Znak" class="invertable" />
-	  <figcaption>Znak</figcaption>
+      <span class="invertable">
+        {% picture logo.png --alt Znak %}
+      </span>
+      <figcaption>Znak</figcaption>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
This PR leverages [Jekyll Picture Tag](https://rbuchberger.github.io/jekyll_picture_tag/) to generate multiple image types without any hassle on our side. 

Whenever you do `bundle exec jekyll serve`, all images will be generated according to the config we specify.

I set it up so that we always serve the correct size for the correct screen - we generate widths 200, 400, 800, 1200 and 1600. 

We also generate a webp version along the png one for every image for older browsers (I could not get avif generation to work). 