### PR TITLE
CI: update artifact upload action to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
           JEKYLL_ENV: production
       - name: ⏫ Upload artifact to GitHub Pages
         id: artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           path: _site/
 


### PR DESCRIPTION
Older ones are deprecated and don't work anymore
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/ https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Fixes #51 